### PR TITLE
feat:予約完了後に予約日時と予約完了メッセージを出力

### DIFF
--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -36,6 +36,7 @@ class ReservationController extends Controller
             'user_id' => $request->user_id,
             'reservation_datetime' => $request->reservation_datetime, // ←ここ追加
         ]);
+        $request->with('message', '保存しました');
 
         return back();
     }

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -36,9 +36,7 @@ class ReservationController extends Controller
             'user_id' => $request->user_id,
             'reservation_datetime' => $request->reservation_datetime, // ←ここ追加
         ]);
-        $request->with('message', '保存しました');
-
-        return back();
+        return redirect()->route('reservation.index')->with('success', '予約が完了しました');
     }
 
     /**

--- a/resources/views/reservation/create.blade.php
+++ b/resources/views/reservation/create.blade.php
@@ -1,18 +1,26 @@
-<div>
-    <form method="post" action="{{ route('reservation.store') }}">
-        @csrf
-        <div>
-            <label for="user_id">予約番号</label>
-            <input type="text" name="user_id">
-
-            <label for="reservation_datetime">予約日時:</label>
-            <input type="datetime-local" name="reservation_datetime" id="reservation_datetime" required>
-        </div>
+<x-app-layout>
+    <x-slot name="header">
+        headerに入る部分
+    </x-slot>
+    
+    <div>
         
-        <div>
-            <x-primary-button>
-                送信する
-            </x-primary-button>
-        </div>
-    </form>
-</div>
+        <form method="post" action="{{ route('reservation.store') }}">
+            @csrf
+            <div>
+                <label for="user_id">予約番号</label>
+                <input type="text" name="user_id">
+
+                <label for="reservation_datetime">予約日時:</label>
+                <input type="datetime-local" name="reservation_datetime" id="reservation_datetime" required>
+            </div>
+            
+            <div>
+                <x-primary-button>
+                    送信する
+                </x-primary-button>
+            </div>
+        </form>
+
+    </div>
+</x-app-layout>

--- a/resources/views/test.blade.php
+++ b/resources/views/test.blade.php
@@ -1,6 +1,8 @@
 こんにちは
+
 @foreach ($reservations as $user)
 <p>
-    {{ $user->name }}
+    {{ $user->user_id }}
+    {{ $user->reservation_datetime }}
 </p>
 @endforeach

--- a/resources/views/test.blade.php
+++ b/resources/views/test.blade.php
@@ -1,6 +1,13 @@
 こんにちは
 
+@if (session('success'))
+            <div class="alert alert-success">
+                {{ session('success') }}
+            </div>
+        @endif
+
 @foreach ($reservations as $user)
+
 <p>
     {{ $user->user_id }}
     {{ $user->reservation_datetime }}


### PR DESCRIPTION
以下の改善を行いました。

- 予約完了後、予約一覧画面へリダイレクトされるように変更
- フラッシュメッセージで「予約が完了しました」と通知を表示
- 一覧画面に予約日時が表示されるようUIを調整
- 送信フォーム画面に `<x-app-layout>` コンポーネントを適用し、レイアウト統一を図った

予約完了後にそのまま一覧に戻れることで、ユーザー体験をより自然にしました。
