### PR TITLE
feat: スタッフによる予約管理機能を実装し、関連するビューを追加

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Laravel') }} - 管理画面</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Scripts -->
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    </head>
+    <body class="font-sans antialiased">
+        <div class="min-h-screen bg-gray-100">
+            @include('admin.layouts.navigation')
+
+            <!-- Page Heading -->
+            @if (isset($header))
+                <header class="bg-white shadow">
+                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                        {{ $header }}
+                    </div>
+                </header>
+            @endif
+
+            <!-- Page Content -->
+            <main>
+                @if (session('success'))
+                    <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
+                        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+                            <span class="block sm:inline">{{ session('success') }}</span>
+                        </div>
+                    </div>
+                @endif
+
+                @if (session('error'))
+                    <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
+                        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+                            <span class="block sm:inline">{{ session('error') }}</span>
+                        </div>
+                    </div>
+                @endif
+
+                {{ $slot }}
+            </main>
+        </div>
+    </body>
+</html>

--- a/resources/views/admin/layouts/navigation.blade.php
+++ b/resources/views/admin/layouts/navigation.blade.php
@@ -1,0 +1,104 @@
+<nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
+    <!-- Primary Navigation Menu -->
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between h-16">
+            <div class="flex">
+                <!-- Logo -->
+                <div class="shrink-0 flex items-center">
+                    <a href="{{ route('admin.dashboard') }}">
+                        <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
+                    </a>
+                </div>
+
+                <!-- Navigation Links -->
+                <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
+                    <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')">
+                        {{ __('ダッシュボード') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('admin.reservations.index')" :active="request()->routeIs('admin.reservations.*')">
+                        {{ __('予約管理') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('admin.holidays.index')" :active="request()->routeIs('admin.holidays.*')">
+                        {{ __('休診日管理') }}
+                    </x-nav-link>
+                </div>
+            </div>
+
+            <!-- Settings Dropdown -->
+            <div class="hidden sm:flex sm:items-center sm:ml-6">
+                <x-dropdown align="right" width="48">
+                    <x-slot name="trigger">
+                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
+                            <div>{{ Auth::guard('admin')->user()->name }}</div>
+
+                            <div class="ml-1">
+                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                                </svg>
+                            </div>
+                        </button>
+                    </x-slot>
+
+                    <x-slot name="content">
+                        <!-- Authentication -->
+                        <form method="POST" action="{{ route('admin.logout') }}">
+                            @csrf
+
+                            <x-dropdown-link :href="route('admin.logout')"
+                                    onclick="event.preventDefault();
+                                                this.closest('form').submit();">
+                                {{ __('ログアウト') }}
+                            </x-dropdown-link>
+                        </form>
+                    </x-slot>
+                </x-dropdown>
+            </div>
+
+            <!-- Hamburger -->
+            <div class="-mr-2 flex items-center sm:hidden">
+                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
+                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Responsive Navigation Menu -->
+    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
+        <div class="pt-2 pb-3 space-y-1">
+            <x-responsive-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')">
+                {{ __('ダッシュボード') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('admin.reservations.index')" :active="request()->routeIs('admin.reservations.*')">
+                {{ __('予約管理') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('admin.holidays.index')" :active="request()->routeIs('admin.holidays.*')">
+                {{ __('休診日管理') }}
+            </x-responsive-nav-link>
+        </div>
+
+        <!-- Responsive Settings Options -->
+        <div class="pt-4 pb-1 border-t border-gray-200">
+            <div class="px-4">
+                <div class="font-medium text-base text-gray-800">{{ Auth::guard('admin')->user()->name }}</div>
+                <div class="font-medium text-sm text-gray-500">{{ Auth::guard('admin')->user()->email }}</div>
+            </div>
+
+            <div class="mt-3 space-y-1">
+                <!-- Authentication -->
+                <form method="POST" action="{{ route('admin.logout') }}">
+                    @csrf
+
+                    <x-responsive-nav-link :href="route('admin.logout')"
+                            onclick="event.preventDefault();
+                                        this.closest('form').submit();">
+                        {{ __('ログアウト') }}
+                    </x-responsive-nav-link>
+                </form>
+            </div>
+        </div>
+    </div>
+</nav>

--- a/resources/views/admin/reservations/create.blade.php
+++ b/resources/views/admin/reservations/create.blade.php
@@ -1,0 +1,63 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('新規予約作成') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="POST" action="{{ route('admin.reservations.store') }}">
+                        @csrf
+
+                        <!-- 顧客選択 -->
+                        <div class="mb-6">
+                            <label for="user_id" class="block text-sm font-medium text-gray-700">顧客</label>
+                            <select name="user_id" id="user_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="">顧客を選択してください</option>
+                                @foreach($users as $user)
+                                    <option value="{{ $user->id }}" {{ old('user_id') == $user->id ? 'selected' : '' }}>
+                                        {{ $user->name }} ({{ $user->email }})
+                                    </option>
+                                @endforeach
+                            </select>
+                            <x-input-error :messages="$errors->get('user_id')" class="mt-2" />
+                        </div>
+
+                        <!-- 予約日 -->
+                        <div class="mb-6">
+                            <label for="reservation_date" class="block text-sm font-medium text-gray-700">予約日</label>
+                            <input type="text" name="reservation_date" id="reservation_date" value="{{ old('reservation_date') }}"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                placeholder="日付を選択してください">
+                            <x-input-error :messages="$errors->get('reservation_date')" class="mt-2" />
+                        </div>
+
+                        <!-- 予約時間 -->
+                        <div class="mb-6">
+                            <label for="reservation_time" class="block text-sm font-medium text-gray-700">予約時間</label>
+                            <select name="reservation_time" id="reservation_time" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="">時間を選択してください</option>
+                                <!-- JavaScriptで動的生成 -->
+                            </select>
+                            <x-input-error :messages="$errors->get('reservation_time')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center justify-end mt-6 space-x-4">
+                            <a href="{{ route('admin.reservations.index') }}" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded">
+                                戻る
+                            </a>
+                            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                                作成
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="{{ asset('js/reservation-calendar.js') }}"></script>
+</x-admin-layout>

--- a/resources/views/admin/reservations/edit.blade.php
+++ b/resources/views/admin/reservations/edit.blade.php
@@ -1,0 +1,68 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('予約編集') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <!-- 現在の予約情報 -->
+                    <div class="mb-8 p-4 bg-blue-50 rounded-lg">
+                        <h3 class="text-lg font-medium text-blue-900 mb-2">現在の予約</h3>
+                        <p class="text-blue-800">
+                            顧客: {{ $reservation->user->name }}<br>
+                            日時: {{ $reservation->reservation_datetime->format('Y年n月j日 (D) H:i') }}
+                        </p>
+                    </div>
+
+                    <form method="POST" action="{{ route('admin.reservations.update', $reservation) }}">
+                        @csrf
+                        @method('PUT')
+
+                        <!-- 顧客情報（変更不可） -->
+                        <div class="mb-6">
+                            <label class="block text-sm font-medium text-gray-700">顧客</label>
+                            <div class="mt-1 p-3 bg-gray-50 border border-gray-300 rounded-md">
+                                {{ $reservation->user->name }} ({{ $reservation->user->email }})
+                            </div>
+                        </div>
+
+                        <!-- 予約日 -->
+                        <div class="mb-6">
+                            <label for="reservation_date" class="block text-sm font-medium text-gray-700">予約日</label>
+                            <input type="text" name="reservation_date" id="reservation_date" 
+                                   value="{{ old('reservation_date', $reservation->reservation_datetime->format('Y-m-d')) }}" 
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                   placeholder="日付を選択してください">
+                            <x-input-error :messages="$errors->get('reservation_date')" class="mt-2" />
+                        </div>
+
+                        <!-- 予約時間 -->
+                        <div class="mb-6">
+                            <label for="reservation_time" class="block text-sm font-medium text-gray-700">予約時間</label>
+                            <select name="reservation_time" id="reservation_time" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="">時間を選択してください</option>
+                                <!-- JavaScriptで動的生成 -->
+                            </select>
+                            <x-input-error :messages="$errors->get('reservation_time')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center justify-end mt-6 space-x-4">
+                            <a href="{{ route('admin.reservations.show', $reservation) }}" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded">
+                                戻る
+                            </a>
+                            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                                更新
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="{{ asset('js/reservation-calendar.js') }}"></script>
+</x-admin-layout>

--- a/resources/views/admin/reservations/index.blade.php
+++ b/resources/views/admin/reservations/index.blade.php
@@ -1,0 +1,133 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('予約管理') }}
+            </h2>
+            <a href="{{ route('admin.reservations.create') }}" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                新規予約作成
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <!-- 検索フィルター -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
+                <div class="p-6">
+                    <form method="GET" action="{{ route('admin.reservations.index') }}" class="flex flex-wrap gap-4">
+                        <div class="flex-1 min-w-0">
+                            <label for="date" class="block text-sm font-medium text-gray-700">日付</label>
+                            <input type="date" name="date" id="date" value="{{ request('date') }}" 
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div class="flex-1 min-w-0">
+                            <label for="user_name" class="block text-sm font-medium text-gray-700">顧客名</label>
+                            <input type="text" name="user_name" id="user_name" value="{{ request('user_name') }}" 
+                                   placeholder="顧客名で検索"
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div class="flex items-end">
+                            <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded">
+                                検索
+                            </button>
+                            <a href="{{ route('admin.reservations.index') }}" class="ml-2 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded">
+                                クリア
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    @if($reservations->count() > 0)
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200">
+                                <thead class="bg-gray-50">
+                                    <tr>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">予約日時</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">顧客名</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">メールアドレス</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">予約日</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ステータス</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="bg-white divide-y divide-gray-200">
+                                    @foreach($reservations as $reservation)
+                                    <tr class="{{ $reservation->reservation_datetime < now() ? 'bg-gray-50' : '' }}">
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <div class="text-sm font-medium text-gray-900">
+                                                {{ $reservation->reservation_datetime->format('Y年n月j日 (D)') }}
+                                            </div>
+                                            <div class="text-sm text-gray-500">
+                                                {{ $reservation->reservation_datetime->format('H:i') }}
+                                            </div>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <div class="text-sm font-medium text-gray-900">
+                                                {{ $reservation->user->name }}
+                                            </div>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <div class="text-sm text-gray-500">
+                                                {{ $reservation->user->email }}
+                                            </div>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <div class="text-sm text-gray-500">
+                                                {{ $reservation->created_at->format('Y年n月j日') }}
+                                            </div>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            @if($reservation->reservation_datetime < now())
+                                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+                                                    完了
+                                                </span>
+                                            @else
+                                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                                    予約中
+                                                </span>
+                                            @endif
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
+                                            <a href="{{ route('admin.reservations.show', $reservation) }}" class="text-indigo-600 hover:text-indigo-900">詳細</a>
+                                            <a href="{{ route('admin.reservations.edit', $reservation) }}" class="text-yellow-600 hover:text-yellow-900">編集</a>
+                                            <form action="{{ route('admin.reservations.destroy', $reservation) }}" method="POST" class="inline" onsubmit="return confirm('本当に削除しますか？')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="text-red-600 hover:text-red-900">削除</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div class="mt-6">
+                            {{ $reservations->withQueryString()->links() }}
+                        </div>
+                    @else
+                        <div class="text-center py-12">
+                            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            <h3 class="mt-2 text-sm font-medium text-gray-900">予約がありません</h3>
+                            <p class="mt-1 text-sm text-gray-500">新しい予約を作成してください。</p>
+                            <div class="mt-6">
+                                <a href="{{ route('admin.reservations.create') }}" class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">
+                                    <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                    </svg>
+                                    新規予約作成
+                                </a>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/reservations/show.blade.php
+++ b/resources/views/admin/reservations/show.blade.php
@@ -1,0 +1,125 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('予約詳細') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <div class="mb-6">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">予約情報</h3>
+                        
+                        <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">予約ID</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    #{{ $reservation->id }}
+                                </dd>
+                            </div>
+                            
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">ステータス</dt>
+                                <dd class="mt-1">
+                                    @if($reservation->reservation_datetime < now())
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                            完了
+                                        </span>
+                                    @else
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                            予約中
+                                        </span>
+                                    @endif
+                                </dd>
+                            </div>
+                            
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">予約日</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->reservation_datetime->format('Y年n月j日 (D)') }}
+                                </dd>
+                            </div>
+                            
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">予約時間</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->reservation_datetime->format('H:i') }}
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="mb-6 border-t border-gray-200 pt-6">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">顧客情報</h3>
+                        
+                        <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">顧客名</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->user->name }}
+                                </dd>
+                            </div>
+                            
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">メールアドレス</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->user->email }}
+                                </dd>
+                            </div>
+                            
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">会員登録日</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->user->created_at->format('Y年n月j日') }}
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="border-t border-gray-200 pt-6">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">予約履歴</h3>
+                        
+                        <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">予約作成日時</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->created_at->format('Y年n月j日 H:i') }}
+                                </dd>
+                            </div>
+                            
+                            @if($reservation->updated_at != $reservation->created_at)
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">最終更新日時</dt>
+                                <dd class="mt-1 text-sm text-gray-900">
+                                    {{ $reservation->updated_at->format('Y年n月j日 H:i') }}
+                                </dd>
+                            </div>
+                            @endif
+                        </dl>
+                    </div>
+
+                    <div class="flex items-center justify-between mt-8 pt-6 border-t border-gray-200">
+                        <a href="{{ route('admin.reservations.index') }}" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded">
+                            一覧に戻る
+                        </a>
+                        
+                        <div class="space-x-2">
+                            <a href="{{ route('admin.reservations.edit', $reservation) }}" class="bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded">
+                                編集
+                            </a>
+                            <form action="{{ route('admin.reservations.destroy', $reservation) }}" method="POST" class="inline" onsubmit="return confirm('本当に削除しますか？')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">
+                                    削除
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/components/admin-layout.blade.php
+++ b/resources/views/components/admin-layout.blade.php
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Laravel') }} - 管理画面</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Flatpickr CSS -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+
+        <!-- Scripts -->
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        
+        <!-- Flatpickr JS -->
+        <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+        <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/ja.js"></script>
+    </head>
+    <body class="font-sans antialiased">
+        <div class="min-h-screen bg-gray-100">
+            @include('admin.layouts.navigation')
+
+            <!-- Page Heading -->
+            @if (isset($header))
+                <header class="bg-white shadow">
+                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                        {{ $header }}
+                    </div>
+                </header>
+            @endif
+
+            <!-- Page Content -->
+            <main>
+                @if (session('success'))
+                    <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
+                        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+                            <span class="block sm:inline">{{ session('success') }}</span>
+                        </div>
+                    </div>
+                @endif
+
+                @if (session('error'))
+                    <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
+                        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+                            <span class="block sm:inline">{{ session('error') }}</span>
+                        </div>
+                    </div>
+                @endif
+
+                {{ $slot }}
+            </main>
+        </div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,13 @@
 <?php
 
-use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\Admin\ReservationController;
 use App\Http\Controllers\Admin\AdminAuthController;
-
-use App\Http\Controllers\ReservationController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\HolidayController;
+
+
 use App\Models\Reservation;
 
 /*
@@ -45,13 +46,17 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
     Route::middleware('auth:admin')->group(function () {
         Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
+        Route::resource('reservations', ReservationController::class);
         Route::resource('holidays', HolidayController::class);
     });
 });
 
 Route::middleware(['auth'])->group(function () {
     // 予約ルート
-    Route::resource('reservations', ReservationController::class);
+    // Route::resource('reservations', ReservationController::class);
+        Route::resource('reservations', \App\Http\Controllers\ReservationController::class);
+
+    
 
     // プロフィール関連
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## 概要

スタッフが任意のユーザーの予約を登録・編集できるようにする機能を追加しました。
あわせて管理用のビュー（一覧・作成・編集）も実装しています。

## 変更内容

- 管理者用のレイアウト `app.blade.php` を追加
- 管理者ナビゲーション `navigation.blade.php` を追加
- 予約一覧画面 `reservations/index.blade.php` を作成
- 予約作成画面 `reservations/create.blade.php` を作成
- 予約編集画面 `reservations/edit.blade.php` を作成

## 動作確認手順

1. `/admin/reservations` にアクセス
2. 「予約作成」ボタンをクリック
3. 予約作成フォームが表示され、ユーザー選択・日時入力が可能なことを確認
4. カレンダーの表示
5. 個別予約の編集、削除

## その他

---