### PR TITLE
feat: 予約関連のリクエストとサービスをリファクタリングし、業務ルールのバリデーションをService層に移譲

### DIFF
--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -2,22 +2,25 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreReservationRequest;
+use App\Http\Requests\UpdateReservationRequest;
 use App\Models\Reservation;
-use App\Models\Holiday;
-use Illuminate\Http\Request;
-use Carbon\Carbon;
+use App\Services\ReservationService;
 use Illuminate\Support\Facades\Auth;
 
 class ReservationController extends Controller
 {
-    public function __construct()
+    protected $reservationService;
+
+    public function __construct(ReservationService $reservationService)
     {
         $this->middleware('auth');
+        $this->reservationService = $reservationService;
     }
 
     public function index()
     {
-       /** @var \App\Models\User $user */
+        /** @var \App\Models\User $user */
         $user = Auth::user();
         $reservations = $user->reservations()
             ->orderBy('reservation_datetime', 'desc')
@@ -31,46 +34,15 @@ class ReservationController extends Controller
         return view('reservations.create');
     }
 
-    public function store(Request $request)
+    public function store(StoreReservationRequest $request)
     {
-        // サーバー側のバリデーション
-        $request->validate([
-            'reservation_date' => 'required|date|after_or_equal:today',
-            'reservation_time' => 'required|date_format:H:i',
-        ]);
+        $data = $request->getServiceData();
 
-        // 文字列を Carbon の日時インスタンスに変換
-        $datetime = Carbon::parse($request->reservation_date . ' ' . $request->reservation_time);
+        // 業務ルールのバリデーション
+        $this->reservationService->validateBusinessRules($data);
 
-        // 休診日チェック
-        $isHoliday = Holiday::where('holiday_date', $datetime->format('Y-m-d'))->exists();
-        if ($isHoliday) {
-            return back()->withErrors(['reservation_date' => 'この日は休診日です。']);
-        }
-
-        // 日曜日チェック
-        if ($datetime->isSunday()) {
-            return back()->withErrors(['reservation_date' => '日曜日は定休日です。']);
-        }
-
-        // ユーザーの未来の予約チェック（1件制限）
-        $userExistingReservation = Reservation::where('user_id', Auth::id())
-            ->where('reservation_datetime', '>', now())
-            ->first();
-        if ($userExistingReservation) {
-            return back()->withErrors(['reservation_date' => 'すでに未来の予約があります。新しい予約をするには既存の予約をキャンセルしてください。']);
-        }
-
-        // 重複チェック
-        $existing = Reservation::where('reservation_datetime', $datetime)->first();
-        if ($existing) {
-            return back()->withErrors(['reservation_time' => 'この時間は既に予約が入っています。']);
-        }
-
-        Reservation::create([
-            'user_id' => Auth::id(),
-            'reservation_datetime' => $datetime,
-        ]);
+        // 予約作成
+        $reservation = $this->reservationService->createReservation($data);
 
         return redirect()->route('reservations.index')
             ->with('success', '予約を受け付けました。');
@@ -102,42 +74,17 @@ class ReservationController extends Controller
         return view('reservations.edit', compact('reservation'));
     }
 
-    public function update(Request $request, Reservation $reservation)
+    public function update(UpdateReservationRequest $request, Reservation $reservation)
     {
-        // 自分の予約のみ更新可能
-        if ($reservation->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $data = $request->getServiceData();
+        $data['user_id'] = $reservation->user_id;
+        $data['reservation_id'] = $reservation->id;
 
-        $request->validate([
-            'reservation_date' => 'required|date|after_or_equal:today',
-            'reservation_time' => 'required|date_format:H:i',
-        ]);
+        // 業務ルールのバリデーション
+        $this->reservationService->validateBusinessRules($data);
 
-        $datetime = Carbon::parse($request->reservation_date . ' ' . $request->reservation_time);
-
-        // 休診日チェック
-        $isHoliday = Holiday::where('holiday_date', $request->reservation_date)->exists();
-        if ($isHoliday) {
-            return back()->withErrors(['reservation_date' => 'この日は休診日です。']);
-        }
-
-        // 日曜日チェック
-        if ($datetime->isSunday()) {
-            return back()->withErrors(['reservation_date' => '日曜日は定休日です。']);
-        }
-
-        // 重複チェック（自分以外）
-        $existing = Reservation::where('reservation_datetime', $datetime)
-            ->where('id', '!=', $reservation->id)
-            ->first();
-        if ($existing) {
-            return back()->withErrors(['reservation_time' => 'この時間は既に予約が入っています。']);
-        }
-
-        $reservation->update([
-            'reservation_datetime' => $datetime,
-        ]);
+        // 予約更新
+        $this->reservationService->updateReservation($reservation, $data);
 
         return redirect()->route('reservations.index')
             ->with('success', '予約を変更しました。');

--- a/app/Http/Requests/AdminStoreReservationRequest.php
+++ b/app/Http/Requests/AdminStoreReservationRequest.php
@@ -2,27 +2,34 @@
 
 namespace App\Http\Requests;
 
+use App\Services\ReservationService;
 use Illuminate\Foundation\Http\FormRequest;
 
 class AdminStoreReservationRequest extends FormRequest
 {
-    // 管理者ガードで認証済みかチェック
+    /**
+     * 管理者ガードで認証済みかチェック
+     */
     public function authorize(): bool
     {
-        // auth('admin')ガードを使用
         return auth('admin')->check();
     }
 
+    /**
+     * 基本的なバリデーションルール（構文チェックのみ）
+     */
     public function rules(): array
     {
         return [
-            'user_id' => 'required|exists:users,id',  // 一般ユーザーから選択
+            'user_id' => 'required|exists:users,id',
             'reservation_date' => 'required|date|after_or_equal:today',
             'reservation_time' => 'required|date_format:H:i',
         ];
     }
 
-    // バリデーションエラーメッセージをカスタマイズし、bladeで表示
+    /**
+     * バリデーションエラーメッセージをカスタマイズ
+     */
     public function messages(): array
     {
         return [
@@ -32,14 +39,41 @@ class AdminStoreReservationRequest extends FormRequest
             'reservation_date.date' => '予約日は有効な日付でなければなりません。',
             'reservation_date.after_or_equal' => '予約日は今日以降の日付でなければなりません。',
             'reservation_time.required' => '予約時間は必須です。',
-            'reservation_time.date_format' => '予約時間は有効な時間形式（H:i)でなければなりません。'
+            'reservation_time.date_format' => '予約時間は有効な時間形式（H:i）でなければなりません。'
         ];
     }
 
-    // バリデーション済の予約日時を文字列で取得
+    /**
+     * 業務ルールのバリデーション（Service層に移譲）
+     */
+    public function validateBusinessRules(): void
+    {
+        $reservationService = app(ReservationService::class);
+
+        $data = [
+            'reservation_datetime' => $this->getReservationDateTime(),
+            'user_id' => $this->user_id,
+        ];
+
+        $reservationService->validateBusinessRules($data);
+    }
+
+    /**
+     * バリデーション済の予約日時を文字列で取得
+     */
     public function getReservationDateTime(): string
     {
         return $this->reservation_date . ' ' . $this->reservation_time;
-        // 例: '2025-07-31 10:00'
+    }
+
+    /**
+     * Serviceで使用するためのデータを取得
+     */
+    public function getServiceData(): array
+    {
+        return [
+            'user_id' => $this->user_id,
+            'reservation_datetime' => $this->getReservationDateTime(),
+        ];
     }
 }

--- a/app/Http/Requests/AdminUpdateReservationRequest.php
+++ b/app/Http/Requests/AdminUpdateReservationRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\ReservationService;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdminUpdateReservationRequest extends FormRequest
+{
+  /**
+   * 管理者ガードで認証済みかチェック
+   */
+  public function authorize(): bool
+  {
+    return auth('admin')->check();
+  }
+
+  /**
+   * 基本的なバリデーションルール（構文チェックのみ）
+   */
+  public function rules(): array
+  {
+    return [
+      'user_id' => 'sometimes|exists:users,id',
+      'reservation_date' => 'required|date',
+      'reservation_time' => 'required|date_format:H:i',
+    ];
+  }
+
+  /**
+   * バリデーションエラーメッセージをカスタマイズ
+   */
+  public function messages(): array
+  {
+    return [
+      'user_id.exists' => '指定されたユーザーが存在しません。',
+      'reservation_date.required' => '予約日は必須です。',
+      'reservation_date.date' => '予約日は有効な日付でなければなりません。',
+      'reservation_time.required' => '予約時間は必須です。',
+      'reservation_time.date_format' => '予約時間は有効な時間形式（H:i）でなければなりません。'
+    ];
+  }
+
+  /**
+   * 業務ルールのバリデーション（Service層に移譲）
+   */
+  public function validateBusinessRules(): void
+  {
+    $reservationService = app(ReservationService::class);
+    $reservation = $this->route('reservation');
+
+    $data = [
+      'reservation_datetime' => $this->getReservationDateTime(),
+      'user_id' => $this->user_id ?? $reservation->user_id,
+      'reservation_id' => $reservation->id,
+    ];
+
+    $reservationService->validateBusinessRules($data);
+  }
+
+  /**
+   * バリデーション済の予約日時を文字列で取得
+   */
+  public function getReservationDateTime(): string
+  {
+    return $this->reservation_date . ' ' . $this->reservation_time;
+  }
+
+  /**
+   * Serviceで使用するためのデータを取得
+   */
+  public function getServiceData(): array
+  {
+    return [
+      'user_id' => $this->user_id,
+      'reservation_datetime' => $this->getReservationDateTime(),
+    ];
+  }
+}

--- a/app/Http/Requests/StoreReservationRequest.php
+++ b/app/Http/Requests/StoreReservationRequest.php
@@ -1,40 +1,78 @@
-<?php 
+<?php
+
 namespace App\Http\Requests;
 
+use App\Services\ReservationService;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Carbon\Carbon;
 
 class StoreReservationRequest extends FormRequest
 {
-    // 他のユーザーの予約操作を防止する
-    public function authorize():bool
+    /**
+     * ユーザーが認証されているかを確認
+     */
+    public function authorize(): bool
     {
-        return true;
+        return Auth::check();
     }
 
-    public function rules():array
-    {
-         return [
-            'reservation_date' => 'required|date|after_or_equal:today',
-            'reservation_time' => 'required|date_format:H:i',
-         ];
-    }
-
-    // バリデーションエラーメッセージをカスタマイズし、bladeで表示
-    public function messages(): array
+    /**
+     * 基本的なバリデーションルール（構文チェックのみ）
+     */
+    public function rules(): array
     {
         return [
-          'reservation_date.required' => '予約日は必須です。',
-          'reservation_date.date' => '予約日は有効な日付でなければなりません。',
-          'reservation_date.after_or_equal' => '予約日は今日以降の日付でなければなりません。',
-          'reservation_time.required' => '予約時間は必須です。',
-          'reservation_time.date_format' => '予約時間は有効な時間形式（H:i)でなければなりません。'  
+            'reservation_date' => 'required|date|after_or_equal:today',
+            'reservation_time' => 'required|date_format:H:i',
         ];
     }
 
-    // バリデーション済の予約日時を文字列で取得
-    public function getReservationDateTime(): string 
+    /**
+     * バリデーションエラーメッセージをカスタマイズ
+     */
+    public function messages(): array
+    {
+        return [
+            'reservation_date.required' => '予約日は必須です。',
+            'reservation_date.date' => '予約日は有効な日付でなければなりません。',
+            'reservation_date.after_or_equal' => '予約日は今日以降の日付でなければなりません。',
+            'reservation_time.required' => '予約時間は必須です。',
+            'reservation_time.date_format' => '予約時間は有効な時間形式（H:i）でなければなりません。'
+        ];
+    }
+
+    /**
+     * 業務ルールのバリデーション（Service層に移譲）
+     */
+    public function validateBusinessRules(): void
+    {
+        $reservationService = app(ReservationService::class);
+
+        $data = [
+            'reservation_datetime' => $this->getReservationDateTime(),
+            'user_id' => Auth::id(),
+        ];
+
+        $reservationService->validateBusinessRules($data);
+    }
+
+    /**
+     * バリデーション済の予約日時を文字列で取得
+     */
+    public function getReservationDateTime(): string
     {
         return $this->reservation_date . ' ' . $this->reservation_time;
-        // 例: '2025-07-31 10:00'
+    }
+
+    /**
+     * Serviceで使用するためのデータを取得
+     */
+    public function getServiceData(): array
+    {
+        return [
+            'user_id' => Auth::id(),
+            'reservation_datetime' => $this->getReservationDateTime(),
+        ];
     }
 }

--- a/app/Http/Requests/UpdateReservationRequest.php
+++ b/app/Http/Requests/UpdateReservationRequest.php
@@ -1,45 +1,81 @@
-<?php 
+<?php
+
 namespace App\Http\Requests;
 
+use App\Services\ReservationService;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Auth; 
+use Illuminate\Support\Facades\Auth;
 
 class UpdateReservationRequest extends FormRequest
 {
-    // 他のユーザーの予約操作を防止する
-    public function authorize():bool
+    /**
+     * 予約の所有者のみが更新可能
+     */
+    public function authorize(): bool
     {
-        // 予約の所有者のみが更新可能
         $reservation = $this->route('reservation');
-        return Auth::check() && 
-                $reservation &&
-                $reservation->user_id === Auth::id();
+        return Auth::check() &&
+            $reservation &&
+            $reservation->user_id === Auth::id();
     }
 
-    public function rules():array
-    {
-         return [
-            'reservation_date' => 'required|date|after_or_equal:today',
-            'reservation_time' => 'required|date_format:H:i',
-         ];
-    }
-
-    // バリデーションエラーメッセージをカスタマイズし、bladeで表示
-    public function messages(): array
+    /**
+     * 基本的なバリデーションルール（構文チェックのみ）
+     */
+    public function rules(): array
     {
         return [
-          'reservation_date.required' => '予約日は必須です。',
-          'reservation_date.date' => '予約日は有効な日付でなければなりません。',
-          'reservation_date.after_or_equal' => '予約日は今日以降の日付でなければなりません。',
-          'reservation_time.required' => '予約時間は必須です。',
-          'reservation_time.date_format' => '予約時間は有効な時間形式（H:i)でなければなりません。'  
+            'reservation_date' => 'required|date|after_or_equal:today',
+            'reservation_time' => 'required|date_format:H:i',
         ];
     }
 
-    // バリデーション済の予約日時を文字列で取得
-    public function getReservationDateTime(): string 
+    /**
+     * バリデーションエラーメッセージをカスタマイズ
+     */
+    public function messages(): array
+    {
+        return [
+            'reservation_date.required' => '予約日は必須です。',
+            'reservation_date.date' => '予約日は有効な日付でなければなりません。',
+            'reservation_date.after_or_equal' => '予約日は今日以降の日付でなければなりません。',
+            'reservation_time.required' => '予約時間は必須です。',
+            'reservation_time.date_format' => '予約時間は有効な時間形式（H:i）でなければなりません。'
+        ];
+    }
+
+    /**
+     * 業務ルールのバリデーション（Service層に移譲）
+     */
+    public function validateBusinessRules(): void
+    {
+        $reservationService = app(ReservationService::class);
+        $reservation = $this->route('reservation');
+
+        $data = [
+            'reservation_datetime' => $this->getReservationDateTime(),
+            'user_id' => $reservation->user_id,
+            'reservation_id' => $reservation->id,
+        ];
+
+        $reservationService->validateBusinessRules($data);
+    }
+
+    /**
+     * バリデーション済の予約日時を文字列で取得
+     */
+    public function getReservationDateTime(): string
     {
         return $this->reservation_date . ' ' . $this->reservation_time;
-        // 例: '2025-07-31 10:00'
+    }
+
+    /**
+     * Serviceで使用するためのデータを取得
+     */
+    public function getServiceData(): array
+    {
+        return [
+            'reservation_datetime' => $this->getReservationDateTime(),
+        ];
     }
 }

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Holiday;
+use App\Models\Reservation;
+use Carbon\Carbon;
+use Illuminate\Validation\ValidationException;
+
+class ReservationService
+{
+  /**
+   * 予約の業務ルールを検証する
+   *
+   * @param array $data
+   * @throws ValidationException
+   */
+  public function validateBusinessRules(array $data): void
+  {
+    $datetime = Carbon::parse($data['reservation_datetime']);
+
+    $this->ensureIsBusinessDay($datetime);
+    $this->ensureNoConflict($datetime, $data['reservation_id'] ?? null);
+
+    if (isset($data['user_id'])) {
+      $this->ensureUserHasNoFutureReservation($data['user_id'], $data['reservation_id'] ?? null);
+    }
+  }
+
+  /**
+   * 営業日かどうかを確認する（日曜日・祝日チェック）
+   *
+   * @param Carbon $datetime
+   * @throws ValidationException
+   */
+  public function ensureIsBusinessDay(Carbon $datetime): void
+  {
+    // 日曜日チェック
+    if ($datetime->isSunday()) {
+      throw ValidationException::withMessages([
+        'reservation_date' => '日曜日は定休日です。'
+      ]);
+    }
+
+    // 休診日チェック
+    $isHoliday = Holiday::where('holiday_date', $datetime->format('Y-m-d'))->exists();
+    if ($isHoliday) {
+      throw ValidationException::withMessages([
+        'reservation_date' => 'この日は休診日です。'
+      ]);
+    }
+  }
+
+  /**
+   * 予約時間の重複がないことを確認する
+   *
+   * @param Carbon $datetime
+   * @param int|null $excludeReservationId 更新時は自分のIDを除外
+   * @throws ValidationException
+   */
+  public function ensureNoConflict(Carbon $datetime, ?int $excludeReservationId = null): void
+  {
+    $query = Reservation::where('reservation_datetime', $datetime);
+
+    if ($excludeReservationId) {
+      $query->where('id', '!=', $excludeReservationId);
+    }
+
+    $existing = $query->first();
+
+    if ($existing) {
+      throw ValidationException::withMessages([
+        'reservation_time' => 'この時間は既に予約が入っています。'
+      ]);
+    }
+  }
+
+  /**
+   * ユーザーが未来の予約を1件以上持っていないことを確認する
+   *
+   * @param int $userId
+   * @param int|null $excludeReservationId 更新時は自分のIDを除外
+   * @throws ValidationException
+   */
+  public function ensureUserHasNoFutureReservation(int $userId, ?int $excludeReservationId = null): void
+  {
+    $query = Reservation::where('user_id', $userId)
+      ->where('reservation_datetime', '>', now());
+
+    if ($excludeReservationId) {
+      $query->where('id', '!=', $excludeReservationId);
+    }
+
+    $existingReservation = $query->first();
+
+    if ($existingReservation) {
+      throw ValidationException::withMessages([
+        'reservation_date' => 'すでに未来の予約があります。新しい予約をするには既存の予約をキャンセルしてください。'
+      ]);
+    }
+  }
+
+  /**
+   * 新しい予約を作成する
+   *
+   * @param array $data
+   * @return Reservation
+   */
+  public function createReservation(array $data): Reservation
+  {
+    // 業務ルールの検証
+    $this->validateBusinessRules($data);
+
+    // 予約を作成
+    return Reservation::create([
+      'user_id' => $data['user_id'],
+      'reservation_datetime' => $data['reservation_datetime'],
+    ]);
+  }
+
+  /**
+   * 既存の予約を更新する
+   *
+   * @param Reservation $reservation
+   * @param array $data
+   * @return Reservation
+   */
+  public function updateReservation(Reservation $reservation, array $data): Reservation
+  {
+    // 更新データに予約IDを追加（重複チェック用）
+    $data['reservation_id'] = $reservation->id;
+    $data['user_id'] = $reservation->user_id;
+
+    // 業務ルールの検証
+    $this->validateBusinessRules($data);
+
+    // 予約を更新
+    $reservation->update([
+      'reservation_datetime' => $data['reservation_datetime'],
+    ]);
+
+    return $reservation->refresh();
+  }
+
+  /**
+   * 管理者用の予約作成（業務ルールが若干異なる場合）
+   *
+   * @param array $data
+   * @return Reservation
+   */
+  public function createReservationAsAdmin(array $data): Reservation
+  {
+    // 管理者の場合も同じ業務ルールを適用
+    $this->validateBusinessRules($data);
+
+    return Reservation::create([
+      'user_id' => $data['user_id'],
+      'reservation_datetime' => $data['reservation_datetime'],
+    ]);
+  }
+
+  /**
+   * 管理者用の予約更新
+   *
+   * @param Reservation $reservation
+   * @param array $data
+   * @return Reservation
+   */
+  public function updateReservationAsAdmin(Reservation $reservation, array $data): Reservation
+  {
+    // 更新データに予約IDを追加
+    $data['reservation_id'] = $reservation->id;
+
+    // ユーザーIDが変更されている場合は新しいユーザーIDを使用
+    if (!isset($data['user_id'])) {
+      $data['user_id'] = $reservation->user_id;
+    }
+
+    // 業務ルールの検証（管理者の場合、一部制限を緩和する可能性もある）
+    $this->validateBusinessRules($data);
+
+    $reservation->update([
+      'user_id' => $data['user_id'] ?? $reservation->user_id,
+      'reservation_datetime' => $data['reservation_datetime'],
+    ]);
+
+    return $reservation->refresh();
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ROOT_HOST: "%"
-      MYSQL_DATABASE: laravel
+      MYSQL_DATABASE: animalhospital
       MYSQL_USER: sail
       MYSQL_PASSWORD: password
     volumes:


### PR DESCRIPTION
## 🔧 概要

予約機能のビジネスロジックおよびバリデーション処理をリファクタリングしました。  
Service層の導入により、コードの保守性と再利用性を向上させ、バリデーションルールの一元管理を実現しています。

---

## ✅ 変更内容

### ● リファクタリングと責務の分離

- `ReservationService` を新規作成し、以下のビジネスロジックを実装  
  - 休診日チェック（日曜・祝日）
  - 重複予約チェック
  - ユーザー予約制限チェック
  - 予約の作成・更新処理の共通化

- `ReservationController` をリファクタし、バリデーションおよび登録処理を `Service層` に委譲

---

### ● バリデーションの強化

- 以下のFormRequestクラスを新規作成・更新し、責務を明確化
  - `StoreReservationRequest`
  - `UpdateReservationRequest`
  - `AdminStoreReservationRequest`
  - `AdminUpdateReservationRequest`

- バリデーションルールとエラーメッセージを各FormRequestに移管

---

### ● DB構成の調整

- `docker-compose.yml` の `MYSQL_DATABASE` を `laravel` → `animalhospital` に変更

---

## 🧪 動作確認手順

1. `http://localhost:8888/reservations/create` にアクセス  
2. バリデーションチェック・予約登録が正しく動作することを確認  
3. `.env` と `docker-compose.yml` のDB名が一致していることを確認  

---

## 📌 補足事項

- 今後、管理者側のControllerについても同様のリファクタを予定  
- テストコードは別PRにて追加予定  

---

## ✅ チェックリスト

- [x] 機能が手動で正常動作することを確認  
- [x] FormRequest によるバリデーションが反映されている  
- [x] 破壊的変更があるため `.env` の同期と `sail down -v` → `sail up -d` が必要  
