### PR TITLE
feat: 予約関連のリクエストとサービスにおける業務ルールのバリデーションをService層に移譲し、基本バリデーションの自動実行を明示化

### DIFF
--- a/app/Http/Controllers/Admin/ReservationController.php
+++ b/app/Http/Controllers/Admin/ReservationController.php
@@ -49,6 +49,8 @@ class ReservationController extends Controller
      */
     public function store(AdminStoreReservationRequest $request)
     {
+        // FormRequestの基本バリデーションは自動実行済み
+        
         // 業務ルールのバリデーション
         $request->validateBusinessRules();
 
@@ -76,6 +78,8 @@ class ReservationController extends Controller
      */
     public function update(AdminUpdateReservationRequest $request, Reservation $reservation)
     {
+        // FormRequestの基本バリデーションは自動実行済み
+        
         // 業務ルールのバリデーション
         $request->validateBusinessRules();
 

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -36,13 +36,10 @@ class ReservationController extends Controller
 
     public function store(StoreReservationRequest $request)
     {
-        $data = $request->getServiceData();
-
-        // 業務ルールのバリデーション
-        $this->reservationService->validateBusinessRules($data);
-
-        // 予約作成
-        $reservation = $this->reservationService->createReservation($data);
+        // FormRequestの基本バリデーションは自動実行済み
+        
+        // 業務ルールのバリデーション + 予約作成
+        $reservation = $this->reservationService->createReservation($request->getServiceData());
 
         return redirect()->route('reservations.index')
             ->with('success', '予約を受け付けました。');
@@ -76,15 +73,11 @@ class ReservationController extends Controller
 
     public function update(UpdateReservationRequest $request, Reservation $reservation)
     {
-        $data = $request->getServiceData();
-        $data['user_id'] = $reservation->user_id;
-        $data['reservation_id'] = $reservation->id;
-
-        // 業務ルールのバリデーション
-        $this->reservationService->validateBusinessRules($data);
-
-        // 予約更新
-        $this->reservationService->updateReservation($reservation, $data);
+        // FormRequestの基本バリデーションは自動実行済み
+        
+        // 業務ルールのバリデーション + 予約更新
+        $this->reservationService->updateReservation($reservation, $request->getServiceData());
+        
         return redirect()->route('reservations.index')
             ->with('success', '予約を変更しました。');
     }

--- a/app/Http/Requests/AdminUpdateReservationRequest.php
+++ b/app/Http/Requests/AdminUpdateReservationRequest.php
@@ -21,7 +21,7 @@ class AdminUpdateReservationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'reservation_date' => 'required|date',
+            'reservation_date' => 'required|date', // 管理者は過去日時も編集可能
             'reservation_time' => 'required|date_format:H:i',
         ];
     }

--- a/app/Http/Requests/StoreReservationRequest.php
+++ b/app/Http/Requests/StoreReservationRequest.php
@@ -43,21 +43,6 @@ class StoreReservationRequest extends FormRequest
     }
 
     /**
-     * 業務ルールのバリデーション（Service層に移譲）
-     */
-    public function validateBusinessRules(): void
-    {
-        $reservationService = app(ReservationService::class);
-
-        $data = [
-            'reservation_datetime' => $this->getReservationDateTime(),
-            'user_id' => Auth::id(),
-        ];
-
-        $reservationService->validateBusinessRules($data);
-    }
-
-    /**
      * バリデーション済の予約日時を文字列で取得
      */
     public function getReservationDateTime(): string

--- a/app/Http/Requests/UpdateReservationRequest.php
+++ b/app/Http/Requests/UpdateReservationRequest.php
@@ -45,23 +45,6 @@ class UpdateReservationRequest extends FormRequest
     }
 
     /**
-     * 業務ルールのバリデーション（Service層に移譲）
-     */
-    public function validateBusinessRules(): void
-    {
-        $reservationService = app(ReservationService::class);
-        $reservation = $this->route('reservation');
-
-        $data = [
-            'reservation_datetime' => $this->getReservationDateTime(),
-            'user_id' => $reservation->user_id,
-            'reservation_id' => $reservation->id,
-        ];
-
-        $reservationService->validateBusinessRules($data);
-    }
-
-    /**
      * バリデーション済の予約日時を文字列で取得
      */
     public function getReservationDateTime(): string
@@ -74,7 +57,10 @@ class UpdateReservationRequest extends FormRequest
      */
     public function getServiceData(): array
     {
+        $reservation = $this->route('reservation');
         return [
+            'user_id' => $reservation->user_id,
+            'reservation_id' => $reservation->id,
             'reservation_datetime' => $this->getReservationDateTime(),
         ];
     }


### PR DESCRIPTION
### 概要

予約処理に関する業務ルールのバリデーションロジックを `ReservationService` に集約し、保守性の向上と重複排除を行いました。  
これにより、コントローラーとリクエストクラスがよりシンプルになり、バリデーションの一貫性も確保されます。

---

### 主な変更点

- `StoreReservationRequest` および `UpdateReservationRequest` 内の業務ルールバリデーションを削除し、`ReservationService` に移譲
- `ReservationController` / `Admin/ReservationController` にて、バリデーションおよび作成・更新処理をサービス層へ統一
- `ReservationService` にバリデーションエラー用定数を追加し、文言の一元管理を実現
- `createReservation` および `updateReservation` 内に業務ルールチェックを統合し、常時適用される構造に変更
- `AdminUpdateReservationRequest` に「管理者は過去の日付を編集可能」であることを明記
- `UpdateReservationRequest::getServiceData()` に `user_id` と `reservation_id` を追加

---

### 動作確認手順

1. ユーザーとして予約の作成・編集を行う
2. バリデーションが適切に動作することを確認
3. 管理者として過去の予約を編集可能なことを確認

---

### その他

- エラー定数の導入により、多言語対応や再利用性が高まりました
- 今後、テストコードの整備を予定しています

---

### チェックリスト

- [x] コントローラー/リクエストクラスからロジックを除去
- [x] バリデーション処理をサービス層へ移譲
- [x] バリデーション定数を導入
- [ ] テストコードの追加（別PRで対応予定）

