### PR TITLE
feature: APIルートのコントローラ移行と静的ページルートの簡素化

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Holiday;
+use App\Models\Reservation;
+use Carbon\Carbon;
+
+class ApiController extends Controller
+{
+  public function holidays()
+  {
+    return Holiday::where('holiday_date', '>=', now()->toDateString())
+      ->pluck('holiday_date')
+      ->map(fn($date) => Carbon::parse($date)->format('Y-m-d'));
+  }
+
+  public function reservationsByDate($date)
+  {
+    return Reservation::whereDate('reservation_datetime', $date)
+      ->pluck('reservation_datetime')
+      ->map(fn($datetime) => Carbon::parse($datetime)->format('H:i'));
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ApiController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,3 +18,6 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/holidays', [ApiController::class, 'holidays']);
+Route::get('/reservations/{date}', [ApiController::class, 'reservationsByDate']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,29 +28,12 @@ use App\Models\Reservation;
 // フロントエンドのルート
 Route::get('/', [HomeController::class, 'index'])->name('home');
 
-Route::get('/faq', function () {
-    return view('pages.faq');
-});
-
-Route::get('/guide', function () {
-    return view('pages.guide');
-});
-
-Route::get('/recruit', function () {
-    return view('pages.recruit');
-});
-
-Route::get('/reservation', function () {
-    return view('pages.reservation');
-});
-
-Route::get('/staff', function () {
-    return view('pages.staff');
-});
-
-Route::get('/facility', function () {
-    return view('pages.facility');
-});
+Route::view('/faq', 'pages.faq')->name('faq');
+Route::view('/guide', 'pages.guide')->name('guide');
+Route::view('/recruit', 'pages.recruit')->name('recruit');
+Route::view('/reservation', 'pages.reservation')->name('reservation');
+Route::view('/staff', 'pages.staff')->name('staff');
+Route::view('/facility', 'pages.facility')->name('facility');
 
 // バックエンドのルート
 Route::prefix('admin')->name('admin.')->group(function () {
@@ -78,19 +61,6 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-});
-
-// API Routes for AJAX
-Route::get('/api/holidays', function () {
-    return \App\Models\Holiday::where('holiday_date', '>=', now()->toDateString())
-        ->pluck('holiday_date')
-        ->map(fn($date) => \Carbon\Carbon::parse($date)->format('Y-m-d'));
-});
-
-Route::get('/api/reservations/{date}', function ($date) {
-    return \App\Models\Reservation::whereDate('reservation_datetime', $date)
-        ->pluck('reservation_datetime')
-        ->map(fn($datetime) => \Carbon\Carbon::parse($datetime)->format('H:i'));
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## 概要

このプルリクエストでは、APIエンドポイント（休診日・予約）の処理を `routes/web.php` のクロージャから専用のコントローラに移行し、静的ページのルート定義を簡素化しました。これにより、コードの整理、保守性、Laravelのベストプラクティスを実現しています。

## 変更内容

### APIリファクタリング・整理

* `app/Http/Controllers/Api/ApiController.php` を新規作成し、休診日・予約APIの処理を移動
* `routes/api.php` に `/holidays` および `/reservations/{date}` を追加し、コントローラに処理を委譲
* `routes/web.php` から既存の休診日・予約APIクロージャを削除し、WebルートとAPIロジックを分離

### フロントエンドルート簡素化

* `routes/web.php` の複数の静的ページルートを `Route::view` で統一し、可読性・保守性を改善

### その他考慮点

* `php artisan route:cache` 実行するためClosure排除
* コード保守性の向上
* APIエンドポイントには `api` ミドルウェア（レート制限・CORS対応）を適用

## 動作確認手順

1. `/api/holidays` にアクセスし、休診日一覧が取得できることを確認
2. `/api/reservations/{date}` にアクセスし、対象日の予約データが取得できることを確認
3. `/faq` `/guide` などの静的ページが `Route::view` で正しく表示されることを確認

## その他

* 今後、テストコードを追加予定です

---
