### PR TITLE
refactor: Admin 認証・ルーティング・ログイン画面の改善

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -21,6 +21,10 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
+                // 管理者ガードの場合は管理者ダッシュボードにリダイレクト
+                if ($guard === 'admin') {
+                    return redirect('/admin/dashboard');
+                }
                 return redirect(RouteServiceProvider::HOME);
             }
         }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -25,7 +25,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(30)->by($request->user()?->id ?: $request->ip());
         });
 
         $this->routes(function () {

--- a/resources/views/admin/auth/login.blade.php
+++ b/resources/views/admin/auth/login.blade.php
@@ -1,54 +1,55 @@
+{{-- クラスベース・コンポーネント(App\View\Components\GuestLayout)で制御 --}}
 <x-guest-layout>
     <div class="max-w-[960px] mx-auto px-4">
-    <!-- Session Status -->
-    <x-auth-session-status class="mb-4" :status="session('status')" />
+        <!-- Session Status -->
+        <x-auth-session-status class="mb-4" :status="session('status')" />
 
-    <div class="mb-4 text-sm text-gray-600 text-center">
-        <h2 class="text-xl font-semibold text-gray-900 mb-2">管理画面ログイン</h2>
-        <p>スタッフ専用のログインページです</p>
-    </div>
-
-    <form method="POST" action="{{ route('admin.login') }}">
-        @csrf
-
-        <!-- Email Address -->
-        <div>
-            <x-input-label for="email" :value="__('メールアドレス')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+        <div class="mb-4 text-sm text-gray-600 text-center">
+            <h2 class="text-xl font-semibold text-gray-900 mb-2">管理画面ログイン</h2>
+            <p>スタッフ専用のログインページです</p>
         </div>
 
-        <!-- Password -->
-        <div class="mt-4">
-            <x-input-label for="password" :value="__('パスワード')" />
+        <form method="POST" action="{{ route('admin.login.store') }}">
+            @csrf
 
-            <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="current-password" />
+            <!-- Email Address -->
+            <div>
+                <x-input-label for="email" :value="__('メールアドレス')" />
+                <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
+                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+            </div>
 
-            <x-input-error :messages="$errors->get('password')" class="mt-2" />
+            <!-- Password -->
+            <div class="mt-4">
+                <x-input-label for="password" :value="__('パスワード')" />
+
+                <x-text-input id="password" class="block mt-1 w-full"
+                    type="password"
+                    name="password"
+                    required autocomplete="current-password" />
+
+                <x-input-error :messages="$errors->get('password')" class="mt-2" />
+            </div>
+
+            <!-- Remember Me -->
+            <div class="block mt-4">
+                <label for="remember_me" class="inline-flex items-center">
+                    <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
+                    <span class="ml-2 text-sm text-gray-600">{{ __('ログイン状態を保持する') }}</span>
+                </label>
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <x-primary-button class="ml-4">
+                    {{ __('ログイン') }}
+                </x-primary-button>
+            </div>
+        </form>
+
+        <div class="mt-6 text-center">
+            <p class="text-xs text-gray-500">
+                一般のお客様は <a href="{{ route('login') }}" class="text-blue-600 hover:text-blue-800">こちら</a> からログインしてください
+            </p>
         </div>
-
-        <!-- Remember Me -->
-        <div class="block mt-4">
-            <label for="remember_me" class="inline-flex items-center">
-                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
-                <span class="ml-2 text-sm text-gray-600">{{ __('ログイン状態を保持する') }}</span>
-            </label>
-        </div>
-
-        <div class="flex items-center justify-end mt-4">           
-            <x-primary-button class="ml-4">
-                {{ __('ログイン') }}
-            </x-primary-button>
-        </div>
-    </form>
-
-    <div class="mt-6 text-center">
-        <p class="text-xs text-gray-500">
-            一般のお客様は <a href="{{ route('login') }}" class="text-blue-600 hover:text-blue-800">こちら</a> からログインしてください
-        </p>
-    </div>
     </div>
 </x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,7 +39,7 @@ Route::view('/facility', 'pages.facility')->name('facility');
 Route::prefix('admin')->name('admin.')->group(function () {
     // Authentication routes
     Route::get('/login', [AdminAuthController::class, 'showLoginForm'])->name('login');
-    Route::post('/login', [AdminAuthController::class, 'login']);
+    Route::post('/login', [AdminAuthController::class, 'login'])->name('login.store');
     Route::post('/logout', [AdminAuthController::class, 'logout'])->name('logout');
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,8 +38,12 @@ Route::view('/facility', 'pages.facility')->name('facility');
 // バックエンドのルート
 Route::prefix('admin')->name('admin.')->group(function () {
     // Authentication routes
-    Route::get('/login', [AdminAuthController::class, 'showLoginForm'])->name('login');
-    Route::post('/login', [AdminAuthController::class, 'login'])->name('login.store');
+    Route::get('/login', [AdminAuthController::class, 'showLoginForm'])
+        ->name('login')
+        ->middleware('guest:admin');
+    Route::post('/login', [AdminAuthController::class, 'login'])
+        ->name('login.store')
+        ->middleware(['guest:admin', 'throttle:login']);
     Route::post('/logout', [AdminAuthController::class, 'logout'])->name('logout');
 
 


### PR DESCRIPTION
## 概要

管理者セクションにおける認証とルーティングを改善し、主にアクセス制御・セキュリティ強化を行いました。  

- 管理者ログイン済みユーザーを `/admin/dashboard` にリダイレクト  
- レートリミットを 60 → 30 に制限  
- ルート定義の整理（`admin.login.store` 導入、`guest:admin` や `throttle:login` の追加）  

---

## 変更内容

- `RedirectIfAuthenticated` ミドルウェアを修正し、`admin` ガード認証済みのユーザーを `/admin/dashboard` にリダイレクト  
- `RouteServiceProvider` の API レート制限を 60 → 30 に変更  
- 管理者ログイン POST ルートを `admin.login.store` に変更  
- `guest:admin` と `throttle:login` ミドルウェアを適用  
- GET ログインルートにも `guest:admin` を追加  
- ログインフォームの POST action を `admin.login.store` に修正  

---

## 理由

- 認証済み管理者の UX 向上（ログインページアクセス時に自動でダッシュボードへ遷移）  
- レートリミットを引き下げて不正アクセス対策を強化  
- ルート名・ビューの統一で可読性と保守性を向上  

---

## 動作確認手順

1. `/admin/login` にアクセス  
   - 認証済みの場合 `/admin/dashboard` にリダイレクトされることを確認  
   - 未認証の場合、ログインフォームが表示されることを確認  
2. ログインフォーム送信時に `admin.login.store` に POST されることを確認  
3. レートリミットを一時的に **3 回/分** に設定し、超過時に制限がかかることを確認  
4. その後、設定を **30 回/分** に戻す  
---
